### PR TITLE
🎽 [just] update "just run_con" to work when you pull and do not build the container

### DIFF
--- a/justfile
+++ b/justfile
@@ -31,6 +31,7 @@ install_prereqs:
 # container build/push variables
 latest_release := `gh release list -L 1 --json name,isLatest | jq -r '.[].name'`
 repo_name := "fini-coredns-example"
+full_repo_name := "ghcr.io/fini-net/fini-coredns-example"
 container_repo := "ghcr.io"
 github_user := "fini-net"
 
@@ -39,12 +40,13 @@ github_user := "fini-net"
 build_con:
 	@echo "{{BLUE}}latest_release={{ latest_release }}{{NORMAL}}"
 	# just makes sure that . is the topmost dir of the git repo
+	# TODO: use full_repo_name in the next line please
 	podman build -t {{ repo_name }}:latest -t {{ repo_name}}:{{ latest_release }} -t {{ container_repo }}/{{ github_user }}/{{ repo_name }}:latest -t {{ container_repo }}/{{ github_user }}/{{ repo_name }}:{{ latest_release }} --build-arg BUILD_VERSION="{{ latest_release }}" .
 
 # run container with podman
 [group('container')]
 run_con:
-	podman run -d --name corednstest -p 1029:53/udp {{ repo_name }} --conf /etc/Corefile
+	podman run -d --name corednstest -p 1029:53/udp {{ full_repo_name }} --conf /etc/Corefile
 
 # clean up containers with podman
 [group('container')]


### PR DESCRIPTION
This PR updates the run_con recipe in the justfile to use a fully qualified container image name, enabling the command to work when pulling containers without building them locally.

Added a new variable full_repo_name containing the complete container registry path
Updated run_con recipe to use the fully qualified name instead of just the repository name

## meta

I tried `just pr` but the quotes broke something.  Then I tried `gh pr create --fill` andI got no description.  👎 