### PR TITLE
🏸 [dnscontrol] rm confusing vestigial auth config

### DIFF
--- a/dns/creds.json
+++ b/dns/creds.json
@@ -4,10 +4,5 @@
   },
   "tucows_opensrs": {
     "TYPE": "OPENSRS"
-  },
-  "r53_accountname": {
-    "TYPE": "ROUTE53",
-    "KeyId": "change_to_your_keyid",
-    "SecretKey": "change_to_your_secretkey"
   }
 }


### PR DESCRIPTION
## Done:

- 🏸 [dnscontrol] rm confusing vestigial auth config

Fixes #34 

(Automated in `justfile`.)
