### PR TITLE
💾 [readme] the dnscontrol repo has moved to a new location

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ![GitHub License](https://img.shields.io/github/license/fini-net/fini-coredns-example)
 
 A complete example demonstrating how to use
-[DNSControl](https://github.com/StackExchange/dnscontrol) to generate DNS zone
+[DNSControl](https://github.com/DNSControl/dnscontrol) to generate DNS zone
 files and serve them with [CoreDNS](https://coredns.io/) in a container.
 
 ![lunchroom banner with logos for coredns, podman, dnscontrol, javascript, and golang](docs/fini-coredns-example-banner2.png)

--- a/docs/coredns_ideas_announce.md
+++ b/docs/coredns_ideas_announce.md
@@ -19,7 +19,7 @@ thing, end to end:
 
 ## What it demonstrates
 
-The core idea is using [DNSControl](https://github.com/StackExchange/dnscontrol)
+The core idea is using [DNSControl](https://github.com/DNSControl/dnscontrol)
 to define DNS records in JavaScript, generating standard BIND zone files,
 and then having CoreDNS serve those zones from a container. Here's the
 full stack:


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- 💾 [readme] the dnscontrol repo has moved to a new location

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
